### PR TITLE
ComposerWindow: Retain GObject style

### DIFF
--- a/src/Composer/ComposerWindow.vala
+++ b/src/Composer/ComposerWindow.vala
@@ -19,20 +19,24 @@
  */
 
 public class Mail.ComposerWindow : Gtk.ApplicationWindow {
+    public string? to { get; construct; default = null; }
+    public string? cc { get; construct; default = null; }
+    public string? subject { get; construct; default = null; }
 
     public ComposerWindow (Gtk.Window parent) {
-        this.with_headers (parent, null, null, null);
+        Object (transient_for: parent);
     }
 
     public ComposerWindow.with_headers (Gtk.Window parent, string? to, string? cc, string? subject) {
         Object (
-            height_request: 600,
-            title: _("New Message"),
             transient_for: parent,
-            width_request: 680,
-            window_position: Gtk.WindowPosition.CENTER_ON_PARENT
+            to: to,
+            cc: cc,
+            subject: subject
         );
+    }
 
+    construct {
         ComposerWidget composer_widget = new ComposerWidget.with_headers (to, cc, subject);
         composer_widget.discarded.connect (() => {
             close ();
@@ -45,6 +49,10 @@ public class Mail.ComposerWindow : Gtk.ApplicationWindow {
         content_grid.orientation = Gtk.Orientation.VERTICAL;
         content_grid.add (composer_widget);
 
+        height_request = 600;
+        width_request = 680;
+        window_position = Gtk.WindowPosition.CENTER_ON_PARENT;
+        title = _("New Message");
         get_style_context ().add_class ("rounded");
         add (content_grid);
     }


### PR DESCRIPTION
This is what I mean with the GObject-style construction stuff. It is a little more verbose, but it ensures that everything we pass into constructors are represented as properties and that the only differences between constructors are due to the arguments they take